### PR TITLE
Add imports for kong_consumer resources to granular-oss kong Terraform provider

### DIFF
--- a/docs/resources/consumer_acl.md
+++ b/docs/resources/consumer_acl.md
@@ -35,7 +35,7 @@ resource "kong_consumer_acl" "consumer_acl" {
 
 ## Import
 
-To import a consumer_acl:
+To import a kong_consumer_acl:
 
 ```shell
 terraform import kong_consumer_acl.<consumer_identifier> <consumer_id>

--- a/docs/resources/consumer_acl.md
+++ b/docs/resources/consumer_acl.md
@@ -31,3 +31,12 @@ resource "kong_consumer_acl" "consumer_acl" {
 * `consumer_id` - (Required) the id of the consumer to be configured
 * `group` - (Required) the acl group
 * `tags` - (Optional) A list of strings associated with the consumer acl for grouping and filtering
+
+
+## Import
+
+To import a consumer_acl:
+
+```shell
+terraform import kong_consumer_acl.<consumer_identifier> <consumer_id>
+```

--- a/docs/resources/consumer_basic_auth.md
+++ b/docs/resources/consumer_basic_auth.md
@@ -32,7 +32,7 @@ resource "kong_consumer_basic_auth" "consumer_basic_auth" {
 
 ## Import
 
-To import a consumer_basic_auth:
+To import a kong_consumer_basic_auth:
 
 ```shell
 terraform import kong_consumer_basic_auth.<consumer_identifier> <consumer_id>

--- a/docs/resources/consumer_basic_auth.md
+++ b/docs/resources/consumer_basic_auth.md
@@ -28,3 +28,12 @@ resource "kong_consumer_basic_auth" "consumer_basic_auth" {
 * `username` - (Required) username to be used for basic auth
 * `password` - (Required) password to be used for basic auth
 * `tags` - (Optional) A list of strings associated with the consumer basic auth for grouping and filtering
+
+
+## Import
+
+To import a consumer_basic_auth:
+
+```shell
+terraform import kong_consumer_basic_auth.<consumer_identifier> <consumer_id>
+```

--- a/docs/resources/consumer_jwt_auth.md
+++ b/docs/resources/consumer_jwt_auth.md
@@ -40,7 +40,7 @@ resource "kong_consumer_jwt_auth" "consumer_jwt_config" {
 
 ## Import
 
-To import a consumer_jwt_auth:
+To import a kong_consumer_jwt_auth:
 
 ```shell
 terraform import kong_consumer_jwt_auth.<consumer_identifier> <consumer_id>

--- a/docs/resources/consumer_jwt_auth.md
+++ b/docs/resources/consumer_jwt_auth.md
@@ -36,3 +36,12 @@ resource "kong_consumer_jwt_auth" "consumer_jwt_config" {
 * `rsa_public_key` - (Optional) If algorithm is `RS256` or `ES256`, the public key (in PEM format) to use to verify the token’s signature
 * `secret` - (Optional) If algorithm is `HS256` or `ES256`, the secret used to sign JWTs for this credential. If left out, will be auto-generated
 * `tags` - (Optional) A list of strings associated with the consumer JWT auth for grouping and filtering
+
+
+## Import
+
+To import a consumer_jwt_auth:
+
+```shell
+terraform import kong_consumer_jwt_auth.<consumer_identifier> <consumer_id>
+```

--- a/docs/resources/consumer_key_auth.md
+++ b/docs/resources/consumer_key_auth.md
@@ -26,3 +26,12 @@ resource "kong_consumer_key_auth" "consumer_key_auth" {
 * `consumer_id` - (Required) the id of the consumer to associate the credentials to
 * `key` - (Optional) Unique key to authenticate the client; if omitted the plugin will generate one
 * `tags` - (Optional) A list of strings associated with the consumer key auth for grouping and filtering
+
+
+## Import
+
+To import a consumer_key_auth:
+
+```shell
+terraform import kong_consumer_key_auth.<consumer_identifier> <consumer_id>
+```

--- a/docs/resources/consumer_key_auth.md
+++ b/docs/resources/consumer_key_auth.md
@@ -30,7 +30,7 @@ resource "kong_consumer_key_auth" "consumer_key_auth" {
 
 ## Import
 
-To import a consumer_key_auth:
+To import a kong_consumer_key_auth:
 
 ```shell
 terraform import kong_consumer_key_auth.<consumer_identifier> <consumer_id>

--- a/kong/resource_kong_consumer_acl.go
+++ b/kong/resource_kong_consumer_acl.go
@@ -3,6 +3,7 @@ package kong
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/kong/go-kong/kong"

--- a/kong/resource_kong_consumer_basic_auth.go
+++ b/kong/resource_kong_consumer_basic_auth.go
@@ -3,6 +3,7 @@ package kong
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/kong/go-kong/kong"
@@ -14,6 +15,9 @@ func resourceKongConsumerBasicAuth() *schema.Resource {
 		ReadContext:   resourceKongConsumerBasicAuthRead,
 		DeleteContext: resourceKongConsumerBasicAuthDelete,
 		UpdateContext: resourceKongConsumerBasicAuthUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"consumer_id": {
 				Type:     schema.TypeString,

--- a/kong/resource_kong_consumer_key_auth.go
+++ b/kong/resource_kong_consumer_key_auth.go
@@ -15,6 +15,9 @@ func resourceKongConsumerKeyAuth() *schema.Resource {
 		ReadContext:   resourceKongConsumerKeyAuthRead,
 		DeleteContext: resourceKongConsumerKeyAuthDelete,
 		UpdateContext: resourceKongConsumerKeyAuthUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"consumer_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Added import for `consumer_kong_key_auth` and `consumer_kong_basic_auth` resources.
Added documentation for all four resources.